### PR TITLE
Replace has_git by test_requires_git

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -15,6 +15,7 @@ on 'test' => sub {
   requires "File::Temp" => "0";
   requires "Test::Fatal" => "0";
   requires "Test::Git" => "1.313";
+  requires "Test::Requires::Git" => "1.005";
   requires "Test::More" => "0";
   requires "perl" => "5.006";
 };

--- a/t/helpers.t
+++ b/t/helpers.t
@@ -5,9 +5,10 @@ use File::Temp qw( tempdir );
 use Git::Helpers qw( checkout_root );
 use Test::Fatal;
 use Test::Git 1.313;
+use Test::Requires::Git;
 use Test::More;
 
-has_git();
+test_requires_git();
 
 my $r = test_repository();
 


### PR DESCRIPTION
Test::Git::has_git is obsolete and replaced by
Test::Requires::Git::test_requires_git.
