### PR TITLE
Bump MetaCPAN::Client to latest version (2.029000)

### DIFF
--- a/.github/workflows/dzil-build-and-test.yml
+++ b/.github/workflows/dzil-build-and-test.yml
@@ -10,6 +10,7 @@ on:
       - "*"
   schedule:
     - cron: "15 4 * * 0" # Every Sunday morning
+  workflow_dispatch:
 
 jobs:
   build-job:

--- a/.github/workflows/dzil-build-and-test.yml
+++ b/.github/workflows/dzil-build-and-test.yml
@@ -17,7 +17,7 @@ jobs:
     name: Build distribution
     runs-on: ubuntu-20.04
     container:
-      image: perldocker/perl-tester:5.32
+      image: perldocker/perl-tester:5.34
     steps:
       - uses: actions/checkout@v2
       - name: Run Tests
@@ -36,7 +36,7 @@ jobs:
     needs: build-job
     runs-on: ubuntu-20.04
     container:
-      image: perldocker/perl-tester:5.32
+      image: perldocker/perl-tester:5.34
     steps:
       - uses: actions/checkout@v2 # codecov wants to be inside a Git repository
       - uses: actions/download-artifact@v2
@@ -55,7 +55,6 @@ jobs:
       matrix:
         os: [ubuntu-20.04]
         perl-version:
-          - "5.10"
           #- "5.12" has been failing for years
           - "5.14"
           - "5.16"
@@ -67,6 +66,7 @@ jobs:
           - "5.28"
           - "5.30"
           - "5.32"
+          - "5.34"
     name: perl ${{ matrix.perl-version }} on ${{ matrix.os }}
     steps:
       - name: set up perl
@@ -94,7 +94,6 @@ jobs:
       matrix:
         os: [macos-latest]
         perl-version:
-          - "5.10"
           #- "5.12" has been failing for years
           - "5.14"
           - "5.16"
@@ -106,6 +105,7 @@ jobs:
           - "5.28"
           - "5.30"
           - "5.32"
+          - "5.34"
     name: Perl ${{ matrix.perl-version }} on macOS
     steps:
       - name: set up perl

--- a/dist.ini
+++ b/dist.ini
@@ -9,3 +9,6 @@ copyright_year   = 2015
 -remove = PruneFiles
 StaticInstall.mode = on
 StaticInstall.dry_run = 0
+
+[Prereqs / RuntimeRequires]
+perl = 5.12.0

--- a/lib/Git/Helpers/CPAN.pm
+++ b/lib/Git/Helpers/CPAN.pm
@@ -2,7 +2,7 @@ package Git::Helpers::CPAN;
 our $VERSION = '1.000001';
 use Moo;
 
-use MetaCPAN::Client ();
+use MetaCPAN::Client 2.029000 ();
 use Try::Tiny qw( try );
 use Types::Standard qw( HashRef InstanceOf Maybe Str );
 


### PR DESCRIPTION
Also bump minimum Perl to 5.12.0 as this is what
Getopt::Long::Descriptive requires.

Fixes #17
